### PR TITLE
Don't Use EGL_EXT_present_opaque on webOS

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -1217,7 +1217,8 @@ EGLSurface *SDL_EGL_CreateSurface(_THIS, NativeWindowType nw)
         }
     }
 
-#ifdef EGL_EXT_present_opaque
+    // webOS 10+ reports EGL_EXT_present_opaque, composition breaks if we use it.
+#if defined(EGL_EXT_present_opaque) && !defined(__WEBOS__)
     if (SDL_EGL_HasExtension(_this, SDL_EGL_DISPLAY_EXTENSION, "EGL_EXT_present_opaque")) {
         const SDL_bool allow_transparent = SDL_GetHintBoolean(SDL_HINT_VIDEO_EGL_ALLOW_TRANSPARENCY, SDL_FALSE);
         attribs[attr++] = EGL_PRESENT_OPAQUE_EXT;


### PR DESCRIPTION
Fixes https://github.com/mariotaku/moonlight-tv/issues/537.