### PR TITLE
Make use of SDL_WEBOS_BROKEN_ABI and add SDL_WEBOS_HAVE_LIBHELPER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ endif()
 
 if(WEBOS)
   set_option(SDL_WEBOS_BROKEN_ABI "Build with webOS modified ABI" OFF)
+  set_option(SDL_WEBOS_HAVE_LIBHELPER "Enable use of libhelper for webOS" ON)
 endif()
 
 # General source files
@@ -1765,6 +1766,9 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS AND NOT HAIKU)
 
     if(SDL_WEBOS_BROKEN_ABI)
       set(HAVE_WEBOS_BROKEN_ABI 1)
+    endif()
+    if(SDL_WEBOS_HAVE_LIBHELPER)
+      add_definitions(-DSDL_WEBOS_HAVE_LIBHELPER=1)
     endif()
 
     if(NOT HAVE_WAYLAND)

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -235,12 +235,14 @@ int SDL_InitSubSystem(Uint32 flags)
     }
     if (!SDL_WebOSInitCalled) {
         SDL_WebOSInitCalled = SDL_TRUE;
+#ifdef SDL_WEBOS_HAVE_LIBHELPER
         SDL_webOSInitLSHandle();
         if (!SDL_webOSAppRegistered()) {
             if (SDL_webOSRegisterApp() != 0) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to register app: %s", SDL_GetError());
             }
         }
+#endif
     }
 #endif
 
@@ -543,7 +545,9 @@ void SDL_Quit(void)
     SDL_DBus_Quit();
 #endif
 #ifdef __WEBOS__
+#ifdef SDL_WEBOS_HAVE_LIBHELPER
     SDL_webOSUnregisterApp();
+#endif
     SDL_webOSUnloadLibraries();
 #endif
 

--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -122,7 +122,7 @@ void SDL_WAYLAND_UnloadSymbols(void)
                     waylandlibs[i].lib = NULL;
                 }
             }
-#ifdef SDL_VIDEO_DRIVER_WAYLAND_WEBOS
+#if defined (SDL_VIDEO_DRIVER_WAYLAND_WEBOS) && defined (SDL_WEBOS_BROKEN_ABI)
             WaylandWebOS_AbiFixFini();
 #endif
 #endif
@@ -172,7 +172,7 @@ int SDL_WAYLAND_LoadSymbols(void)
         if(!WAYLAND_wl_proxy_marshal_constructor_versioned) {
             WAYLAND_wl_proxy_marshal_constructor_versioned = FALLBACK_wl_proxy_marshal_constructor_versioned;
         }
-#ifdef SDL_VIDEO_DRIVER_WAYLAND_WEBOS
+#if defined (SDL_VIDEO_DRIVER_WAYLAND_WEBOS) && defined (SDL_WEBOS_BROKEN_ABI)
         if (WaylandWebOS_AbiFixInit() != 0) {
             rc = 0;
         }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -962,7 +962,11 @@ static void display_handle_global(void *data, struct wl_registry *registry, uint
     } else if (SDL_strcmp(interface, "wl_webos_input_manager") == 0) {
         // Danger! Requests of wl_webos_input_manager has completely broken ABI.
         // NEVER use this interface directly.
+#ifdef SDL_WEBOS_BROKEN_ABI
         d->webos_input_manager = wl_registry_bind(registry, id, WaylandWebOS_AbiFixGetInterface(interface), 1);
+#else
+        d->webos_input_manager = wl_registry_bind(registry, id, &wl_webos_input_manager_interface, 1);
+#endif
         wl_webos_input_manager_add_listener(d->webos_input_manager, &webos_input_manager_listener, d);
     } else if (SDL_strcmp(interface, "wl_starfish_pointer") == 0) {
         SDL_VideoDevice *device = SDL_GetVideoDevice();

--- a/src/video/wayland/SDL_waylandwebos.c
+++ b/src/video/wayland/SDL_waylandwebos.c
@@ -184,7 +184,9 @@ static void webos_shell_handle_state(void *data, struct wl_webos_shell_surface *
 {
     SDL_WindowData *d = data;
     if (state == WL_WEBOS_SHELL_SURFACE_STATE_MINIMIZED) {
+#ifdef SDL_WEBOS_HAVE_LIBHELPER
         HELPERS_HProcessAppState(3, NULL);
+#endif
         SDL_SendWindowEvent(d->sdlwindow, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
         SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
         SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
@@ -193,7 +195,9 @@ static void webos_shell_handle_state(void *data, struct wl_webos_shell_surface *
             SDL_SendWindowEvent(d->sdlwindow, SDL_WINDOWEVENT_RESTORED, 0, 0);
             SDL_SendAppEvent(SDL_APP_WILLENTERFOREGROUND);
             SDL_SendAppEvent(SDL_APP_DIDENTERFOREGROUND);
+#ifdef SDL_WEBOS_HAVE_LIBHELPER
             HELPERS_HProcessAppState(0, NULL);
+#endif
         }
     }
     d->webos_shell_state = state;
@@ -222,7 +226,9 @@ static void webos_shell_handle_state_about_to_change(void *data, struct wl_webos
         return;
     }
     SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
+#ifdef SDL_WEBOS_HAVE_LIBHELPER
     HELPERS_HProcessAppState(1, NULL);
+#endif
 }
 
 static void WindowHintsCallback(void *userdata, const char *name, const char *oldValue, const char *newValue)

--- a/src/video/wayland/SDL_waylandwebos_cursor.c
+++ b/src/video/wayland/SDL_waylandwebos_cursor.c
@@ -17,6 +17,9 @@ char WaylandWebOS_GetCursorSize()
     jdomparser_ref parser = NULL;
     jvalue_ref parsed = NULL;
     char size = 'M';
+#ifndef SDL_WEBOS_HAVE_LIBHELPER
+    return 'M';
+#endif
     if (!SDL_webOSLunaServiceCallSync(uri, payload, 1, &response)) {
         return 'M';
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Even if you pass SDL_WEBOS_BROKEN_ABI=OFF, it will still use its methods. This just passes the setting across for that code.

Add the option to compile without luna calls. Needed as libhelpers does not exist on 64-bit. Defaults to ON so makes no difference negatively. Will segfault otherwise. SDL2 works fine otherwise.

## Existing Issue(s)
This is an issue for me as libwayland-webos-client.so.1 has no aarch64 equivalent.